### PR TITLE
added NOINLINE to error function

### DIFF
--- a/libraries/base/GHC/Err.hs
+++ b/libraries/base/GHC/Err.hs
@@ -13,7 +13,6 @@ module GHC.Err
 import GHC.Types
 -- import GHC.Exception
 
-
 {-# NOINLINE error #-}
 error :: [Char] -> a
 error s = error s -- throw (ErrorCall s)

--- a/libraries/base/GHC/Err.hs
+++ b/libraries/base/GHC/Err.hs
@@ -13,6 +13,8 @@ module GHC.Err
 import GHC.Types
 -- import GHC.Exception
 
+
+{-# NOINLINE error #-}
 error :: [Char] -> a
 error s = error s -- throw (ErrorCall s)
 

--- a/libraries/base/GHC/List.hs
+++ b/libraries/base/GHC/List.hs
@@ -324,6 +324,7 @@ unzip3   :: [(a,b,c)] -> ([a],[b],[c])
 {-# INLINE unzip3 #-}
 unzip3   =  foldr (\(a,b,c) ~(as,bs,cs) -> (a:as,b:bs,c:cs))
                   ([],[],[])
+
 {-# NOINLINE errorEmptyList #-}
 errorEmptyList :: String -> a
 errorEmptyList fun = errorEmptyList fun

--- a/libraries/base/GHC/List.hs
+++ b/libraries/base/GHC/List.hs
@@ -324,6 +324,6 @@ unzip3   :: [(a,b,c)] -> ([a],[b],[c])
 {-# INLINE unzip3 #-}
 unzip3   =  foldr (\(a,b,c) ~(as,bs,cs) -> (a:as,b:bs,c:cs))
                   ([],[],[])
-
+{-# NOINLINE errorEmptyList #-}
 errorEmptyList :: String -> a
 errorEmptyList fun = errorEmptyList fun


### PR DESCRIPTION
this fixes a bug where lcvm will fail to load GHC.Err and anything else which imports it. I'm not entirely sure why though; this fix was based on a hunch
